### PR TITLE
chore(ci): disable recently updated ops-bot check

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,5 +5,5 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-recently_updated: true
+recently_updated: false
 forward_merger: true


### PR DESCRIPTION
The recently updated check is hanging in every PR and I'm not sure why, but given the current rate of development in this repo, and that there isn't currently any CI to run, I propose disabling it until we're in a place where we actually need it.
