### PR TITLE
expand CI-skipping logic, other small build changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,25 +56,67 @@ jobs:
       files_yaml: |
         test_cpp:
           - '**'
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
+          - '!.github/CODEOWONERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/workflows/labeler.yml'
           - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/build_python.sh'
+          - '!ci/build_wheel*.sh'
+          - '!ci/check_style.sh'
           - '!ci/release/update-version.sh'
+          - '!ci/run_cuforest_pytests.sh'
+          - '!ci/test_python.sh'
+          - '!ci/test_wheel.sh'
+          - '!ci/validate_wheel.sh'
           - '!docs/**'
           - '!python/**'
           - '!**/*/agents.md'
-          - '!.coderabbit.yaml'
-        test_python:
+        test_python_conda:
           - '**'
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
+          - '!.github/CODEOWONERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/workflows/labeler.yml'
           - '!.pre-commit-config.yaml'
-          - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/build_wheel*.sh'
+          - '!ci/check_style.sh'
           - '!ci/release/update-version.sh'
+          - '!ci/run_ctests.sh'
+          - '!ci/test_cpp.sh'
+          - '!ci/test_wheel.sh'
+          - '!ci/validate_wheel.sh'
           - '!docs/**'
           - '!**/*/agents.md'
+        test_python_wheels:
+          - '**'
           - '!.coderabbit.yaml'
+          - '!.devcontainer/**'
+          - '!.github/CODEOWONERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/workflows/labeler.yml'
+          - '!.pre-commit-config.yaml'
+          - '!README.md'
+          - '!ci/build_cpp.sh'
+          - '!ci/build_python.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/update-version.sh'
+          - '!ci/run_ctests.sh'
+          - '!ci/test_cpp.sh'
+          - '!ci/test_python.sh'
+          - '!conda/**'
+          - '!docs/**'
+          - '!**/*/agents.md'
   checks:
     secrets: inherit
     needs: telemetry-setup
@@ -129,7 +171,7 @@ jobs:
     needs: [conda-python-build, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       build_type: pull-request
       script: "ci/test_python.sh"
@@ -166,7 +208,7 @@ jobs:
     needs: [wheel-build-cuforest, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
       script: ci/test_wheel.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
             pass_filenames: false
             language: python
     - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v1.2.1
+      rev: v1.3.3
       hooks:
         - id: verify-copyright
           name: verify-copyright
@@ -102,6 +102,12 @@ repos:
               dependencies[.]yaml$|
               pytest[.]ini$
         - id: verify-alpha-spec
+        - id: verify-pyproject-license
+          # ignore the top-level pyproject.toml, which doesn't
+          # have or need a [project] table
+          exclude: |
+            (?x)
+              ^pyproject[.]toml$
     - repo: https://github.com/rapidsai/dependency-file-generator
       rev: v1.20.0
       hooks:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,6 +9,8 @@ package_dir=$2
 
 source rapids-configure-sccache
 source rapids-date-string
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/wheel/preprocessor-cache"

--- a/ci/build_wheel_cuforest.sh
+++ b/ci/build_wheel_cuforest.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 package_name="cuforest"

--- a/ci/build_wheel_libcuforest.sh
+++ b/ci/build_wheel_libcuforest.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 package_name="libcuforest"

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -234,11 +234,6 @@ dependencies:
           - packaging
           - &scikit_learn scikit-learn>=1.5
           - *treelite
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
   cuda_version:
     specific:
       - output_types: conda
@@ -429,7 +424,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -458,7 +452,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -482,7 +475,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]


### PR DESCRIPTION
## Description

Proposes a batch of miscellaneous build / packaging / CI changes.

## Changes

### Expands CI-skipping logic

Contributes to https://github.com/rapidsai/build-planning/issues/243

Tries to avoid unnecessary CI runs by making the CI-skipping rules finer-grained. For example, PRs that only touch `.pre-commit-config.yaml` should now not require any runners with GPUs 😁 

### Removes reliance on `pypi.nvidia.com`

Contributes to https://github.com/rapidsai/build-planning/issues/241

```shell
git grep -i -E 'pypi\.nvidia\.com'
git grep -i -E 'rapids\-init\-pip'
```

And removed/updated all relevant references. This project does not need any wheels from `pypi.nvidia.com` at build-time or runtime, it can safely avoid searching that index.

### Enforces PEP 639 license metadata in `pyproject.toml`

Contributes to https://github.com/rapidsai/pre-commit-hooks/issues/95