### PR TITLE
add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# nvForest initial public development (March 2026)
+
+Public development on nvForest began in March 2026.


### PR DESCRIPTION
Contributes to #13 

After https://github.com/rapidsai/docs/pull/755, nvForest docs are now live on the docs site: https://docs.rapids.ai/api/

The RAPIDS docs site code automatically adds a link to `CHANGELOG.md` for each project, expected to be at the repo root. This project doesn't have one yet, so that link is broken.

This adds a minimal `CHANGELOG.md` file to fix that.