### PR TITLE
trim docs environment

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -78,9 +78,6 @@ files:
       - cuda_version
       - docs
       - py_version
-      - depends_on_cuda_python
-      - depends_on_libraft_headers
-      - depends_on_librmm
       - depends_on_nvforest
       - depends_on_libnvforest
   test_cpp:


### PR DESCRIPTION
Replaces #57, which I accidentally closed by deleting my fork when the repo was flipped to public.

The `docs` group in `rapids-dependency-file-generator` currently re-declares a couple of dependencies which are only needed because they're direct dependencies of `libnvforest` / `nvforest`.

Those should just be pulled through directly via installing `libnvforest` / `nvforest`:

https://github.com/rapidsai/nvforest/blob/9d2863124b3bd79b4f9a79d6e9c7f7a95d37bfdf/ci/build_docs.sh#L7-L8

This removes them from that list, so the `docs` environment will get smaller if those dependencies are ever removed here.