### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       hooks:
           - id: cython-lint
     - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: v20.1.4
+      rev: v20.1.8
       hooks:
           - id: clang-format
             types_or: [c, c++, cuda]

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -33,7 +33,7 @@ We aim to meet the `SPEC 0 guidelines <https://scientific-python.org/specs/spec-
 
 **For development only.**
 
-* clang-format (= 20.1.4): enforces uniform C++ coding style; required for pre-commit hooks and CI checks. The packages ``clang=20`` and ``clang-tools=20`` from the conda-forge channel should be sufficient, if you are using conda. If not using conda, install the right version using your OS package manager.
+* clang-format (= 20.1.8): enforces uniform C++ coding style; required for pre-commit hooks and CI checks. The packages ``clang=20`` and ``clang-tools=20`` from the conda-forge channel should be sufficient, if you are using conda. If not using conda, install the right version using your OS package manager.
 
 .. note:: Use Conda to install all software dependencies
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
