### PR TITLE
Consistently choose between NumPy and cuPy array types

### DIFF
--- a/python/nvforest/nvforest/detail/forest_inference.pyx
+++ b/python/nvforest/nvforest/detail/forest_inference.pyx
@@ -158,7 +158,7 @@ cdef class ForestInference_impl():
         elif isinstance(X, cp.ndarray):
             X_type = "cupy"
         else:
-            raise ValueError("X must be either NumPy or cuPy array")
+            raise TypeError("X must be either NumPy or cuPy array")
 
         if len(X.shape) != 2:
             raise ValueError("Expected a 2D array for X")
@@ -241,7 +241,8 @@ cdef class ForestInference_impl():
             raise ValueError(f"Unrecognized predict_type: {predict_type}")
 
         if self.device == "cpu":
-            X_converted = np.asarray(cp.asnumpy(X), dtype=model_dtype, order="C")
+            X_converted = cp.asnumpy(X) if X_type == "cupy" else X
+            X_converted = np.asarray(X_converted, dtype=model_dtype, order="C")
             preds = np.empty(
                 shape=output_shape,
                 dtype=model_dtype,

--- a/python/nvforest/nvforest/detail/forest_inference.pyx
+++ b/python/nvforest/nvforest/detail/forest_inference.pyx
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
+import cupy as cp
 import numpy as np
 import treelite
 
@@ -142,6 +143,32 @@ cdef class ForestInference_impl():
             "Failed to free Treelite model:"
         )
 
+    def _validate_input(self, X: DataType) -> Literal["numpy", "cupy"]:
+        """
+        Ensure the following:
+        1. X is a NumPy or cuPy array.
+        2. X has valid dimensions
+
+        The function returns either "numpy" or "cupy", indicating
+        the array type for X.
+        """
+
+        if isinstance(X, np.ndarray):
+            X_type = "numpy"
+        elif isinstance(X, cp.ndarray):
+            X_type = "cupy"
+        else:
+            raise ValueError("X must be either NumPy or cuPy array")
+
+        if len(X.shape) != 2:
+            raise ValueError("Expected a 2D array for X")
+        if X.shape[1] != self.num_features():
+            raise ValueError(
+                f"Expected {self.num_features()} features in the input "
+                f"but X has {X.shape[1]} features"
+            )
+        return X_type
+
     def get_dtype(self):
         return [np.float32, np.float64][self.model.is_double_precision()]
 
@@ -194,6 +221,7 @@ cdef class ForestInference_impl():
         cdef infer_kind infer_type_enum
         cdef optional[uint32_t] chunk_specification
 
+        X_type = self._validate_input(X)
         n_rows = X.shape[0]
         model_dtype = self.get_dtype()
 
@@ -213,26 +241,25 @@ cdef class ForestInference_impl():
             raise ValueError(f"Unrecognized predict_type: {predict_type}")
 
         if self.device == "cpu":
-            X = np.asarray(X, dtype=model_dtype, order="C")
+            X_converted = np.asarray(cp.asnumpy(X), dtype=model_dtype, order="C")
             preds = np.empty(
                 shape=output_shape,
                 dtype=model_dtype,
                 order="C",
             )
-            in_ptr = X.__array_interface__["data"][0]
+            in_ptr = X_converted.__array_interface__["data"][0]
             in_dev = raft_proto_device_t.cpu
             out_ptr = preds.__array_interface__["data"][0]
             out_dev = raft_proto_device_t.cpu
         else:
             assert self.device == "gpu"
-            import cupy as cp
-            X = cp.asarray(X, dtype=model_dtype, order="C", blocking=True)
+            X_converted = cp.asarray(X, dtype=model_dtype, order="C", blocking=True)
             preds = cp.empty(
                 shape=output_shape,
                 dtype=model_dtype,
                 order="C",
             )
-            in_ptr = X.__cuda_array_interface__["data"][0]
+            in_ptr = X_converted.__cuda_array_interface__["data"][0]
             in_dev = raft_proto_device_t.gpu
             out_ptr = preds.__cuda_array_interface__["data"][0]
             out_dev = raft_proto_device_t.gpu
@@ -267,6 +294,13 @@ cdef class ForestInference_impl():
 
         if self.device == "gpu":
             self.raft_proto_handle.synchronize()
+
+        # X and preds must be the same type
+        if X_type == "numpy":
+            preds = cp.asnumpy(preds)
+        elif X_type == "cupy":
+            preds = cp.asarray(preds)
+
         return preds
 
 
@@ -355,22 +389,12 @@ class ForestInferenceImpl:
     def elem_postprocessing(self) -> str:
         return self.impl.elem_postprocessing()
 
-    def _validate_input_dims(self, X: DataType) -> None:
-        if len(X.shape) != 2:
-            raise ValueError("Expected a 2D array for X")
-        if X.shape[1] != self.num_features:
-            raise ValueError(
-                f"Expected {self.num_features} features in the input "
-                f"but X has {X.shape[1]} features"
-            )
-
     def predict(
         self,
         X: DataType,
         *,
         chunk_size: Optional[int] = None,
     ) -> DataType:
-        self._validate_input_dims(X)
         # Returns probabilities if the model is a classifier
         return self.impl.predict(
             X, chunk_size=(chunk_size or self.default_chunk_size)
@@ -382,7 +406,6 @@ class ForestInferenceImpl:
         *,
         chunk_size: Optional[int] = None,
     ) -> DataType:
-        self._validate_input_dims(X)
         chunk_size = (chunk_size or self.default_chunk_size)
         return self.impl.predict(
             X, predict_type="per_tree", chunk_size=chunk_size
@@ -394,7 +417,6 @@ class ForestInferenceImpl:
         *,
         chunk_size: Optional[int] = None,
     ) -> DataType:
-        self._validate_input_dims(X)
         chunk_size = (chunk_size or self.default_chunk_size)
         return self.impl.predict(
             X, predict_type="leaf_id", chunk_size=chunk_size

--- a/python/nvforest/tests/test_nvforest.py
+++ b/python/nvforest/tests/test_nvforest.py
@@ -882,3 +882,43 @@ def test_incorrect_data_shape(input_size, predict_func):
     with pytest.raises(ValueError, match=f"Expected {n_features} features"):
         X_test = np.zeros((1, input_size))
         _ = predict_func(fm, X_test)
+
+
+@pytest.mark.parametrize("device", ("cpu", "gpu"))
+def test_array_type(device):
+    """
+    Ensure that nvForest makes consistent choices between NumPy and cuPy array types.
+    If X is a NumPy array, predict(X) should return a NumPy array.
+    If X is a cuPy array, predict(X) should return a cuPy array.
+    """
+    builder = treelite.model_builder.ModelBuilder(
+        threshold_type="float32",
+        leaf_output_type="float32",
+        metadata=treelite.model_builder.Metadata(
+            num_feature=1,
+            task_type="kRegressor",
+            average_tree_output=False,
+            num_target=1,
+            num_class=[1],
+            leaf_vector_shape=(1, 1),
+        ),
+        tree_annotation=treelite.model_builder.TreeAnnotation(
+            num_tree=1, target_id=[0], class_id=[0]
+        ),
+        postprocessor=treelite.model_builder.PostProcessorFunc(
+            name="identity"
+        ),
+        base_scores=[0.0],
+    )
+    builder.start_tree()
+    builder.start_node(0)
+    builder.leaf(0.0)
+    builder.end_node()
+    builder.end_tree()
+    tl_model = builder.commit()
+
+    nvforest_model = nvforest.load_from_treelite_model(tl_model, device=device)
+    X_numpy = np.array([[0.0]], dtype="float32")
+    X_cupy = cp.array([[0.0]], dtype="float32")
+    assert isinstance(nvforest_model.predict(X_numpy), np.ndarray)
+    assert isinstance(nvforest_model.predict(X_cupy), cp.ndarray)


### PR DESCRIPTION
nvForest performs zero type conversions and only supports NumPy and cuPy arrays. This pull request makes a small quality-of-life improvement with a tiny overhead, by ensuring the following behavior:

1. If `X` is a NumPy array, `predict(X)` should return a NumPy array.
2. If `X` is a cuPy array, `predict(X)` should return a cuPy array.