### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: libnvforest
       package-type: cpp
-      publish-wheel-search-key: libnvforest_wheel_cpp_nvforest
+      publish-wheel-search-key: nvforest_wheel_cpp_libnvforest
   wheel-build-nvforest:
     needs: wheel-build-libnvforest
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,6 +145,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: libnvforest
       package-type: cpp
+      publish-wheel-search-key: libnvforest_wheel_cpp_nvforest
   wheel-build-nvforest:
     needs: wheel-build-libnvforest
     permissions:
@@ -185,7 +186,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: nvforest
       package-type: python
-      publish-wheel-search-key: nvforest_wheel_python_abi3
+      publish-wheel-search-key: nvforest_wheel_python_nvforest
   devcontainers:
     name: Build devcontainers
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,6 +230,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@main
     with:
       build_type: pull-request
+      package_name: libnvforest
   conda-python-build:
     needs: conda-cpp-build
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      package_name: libnvforest
   conda-cpp-tests:
     permissions:
       actions: read

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -34,3 +34,6 @@ sccache --stop-server >/dev/null 2>&1 || true
 # remove build_cache directory to avoid uploading the entire source tree
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python nvforest --stable --cuda)")
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python nvforest nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -13,7 +13,7 @@ rapids-print-env
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")")
 
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version)
 export RAPIDS_PACKAGE_VERSION

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -43,5 +43,5 @@ sccache --stop-server >/dev/null 2>&1 || true
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python nvforest --stable --cuda)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python nvforest nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_libnvforest.sh
+++ b/ci/build_wheel_libnvforest.sh
@@ -51,3 +51,6 @@ python -m auditwheel repair \
     ${package_dir}/dist/*
 
 ./ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_nvforest.sh
+++ b/ci/build_wheel_nvforest.sh
@@ -16,7 +16,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 #
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
 # 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
-LIBNVFOREST_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libnvforest_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+LIBNVFOREST_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")")
 echo "libnvforest-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBNVFOREST_WHEELHOUSE}"/libnvforest_*.whl)" >> "${PIP_CONSTRAINT}"
 
 EXCLUDE_ARGS=(
@@ -51,5 +51,5 @@ python -m auditwheel repair \
 
 ./ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name wheel_python nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python nvforest nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -13,7 +13,7 @@ rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -13,8 +13,8 @@ rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python nvforest --stable --cuda)")
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python nvforest nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -6,9 +6,8 @@ set -euo pipefail
 
 source rapids-init-pip
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-NVFOREST_WHEELHOUSE=$(rapids-download-from-github "$(rapids-package-name wheel_python nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")")
-LIBNVFOREST_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libnvforest_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+LIBNVFOREST_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libnvforest nvforest --cuda "$RAPIDS_CUDA_VERSION")")
+NVFOREST_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python nvforest nvforest --stable --cuda "$RAPIDS_CUDA_VERSION")")
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}"
 


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270