### PR TITLE
Update CuPy and NumPy dependency specs

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0a0
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.0
 - doxygen
@@ -24,7 +24,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - ninja
-- numpy>=1.23,<3.0a0
+- numpy>=2.0,<3.0a0
 - numpydoc
 - packaging
 - pandas

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0a0
 - cuda-version=12.9
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.0
 - doxygen
@@ -24,7 +24,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - ninja
-- numpy>=1.23,<3.0a0
+- numpy>=2.0,<3.0a0
 - numpydoc
 - packaging
 - pandas

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0a0
 - cuda-version=13.3
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.0
 - doxygen
@@ -24,7 +24,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - ninja
-- numpy>=1.23,<3.0a0
+- numpy>=2.0,<3.0a0
 - numpydoc
 - packaging
 - pandas

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0a0
 - cuda-version=13.3
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.0
 - doxygen
@@ -24,7 +24,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - ninja
-- numpy>=1.23,<3.0a0
+- numpy>=2.0,<3.0a0
 - numpydoc
 - packaging
 - pandas

--- a/conda/recipes/nvforest/recipe.yaml
+++ b/conda/recipes/nvforest/recipe.yaml
@@ -92,9 +92,9 @@ requirements:
       else: cuda-python >=13.0.1,<14.0a0
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-    - cupy >=13.6.0,!=14.0.0,!=14.1.0
+    - cupy >=14.0.1,!=14.1.0
     - libnvforest =${{ version }}
-    - numpy >=1.23,<3.0a0
+    - numpy >=2.0,<3.0a0
     - scikit-learn >=1.4
     - pylibraft =${{ minor_version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -450,23 +450,23 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=14.0.1,!=14.1.0
+              - &cupy_cu12 cupy-cuda12x>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=14.0.1,!=14.1.0
+              - &cupy_cu13 cupy-cuda13x>=14.0.1,!=14.1.0
       - output_types: pyproject
         matrices:
           - matrix:
               cuda: "12.*"
               use_cuda_wheels: "false"
             packages:
-              - cupy-cuda12x>=14.0.1,!=14.1.0
+              - *cupy_cu12
           - matrix:
               cuda: "13.*"
               use_cuda_wheels: "false"
             packages:
-              - cupy-cuda13x>=14.0.1,!=14.1.0
+              - *cupy_cu13
           - matrix:
               cuda: "12.*"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -445,8 +445,28 @@ dependencies:
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
     specific:
-      - output_types: [requirements, pyproject]
+      - output_types: requirements
         matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cupy-cuda12x>=14.0.1,!=14.1.0
+          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
+          - matrix:
+            packages:
+              - cupy-cuda13x>=14.0.1,!=14.1.0
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              use_cuda_wheels: "false"
+            packages:
+              - cupy-cuda12x>=14.0.1,!=14.1.0
+          - matrix:
+              cuda: "13.*"
+              use_cuda_wheels: "false"
+            packages:
+              - cupy-cuda13x>=14.0.1,!=14.1.0
           - matrix:
               cuda: "12.*"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -237,7 +237,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - numpy>=1.23,<3.0a0
+          - numpy>=2.0,<3.0a0
           - &scikit_learn scikit-learn>=1.5
           - *treelite
   # 'cuda_version' intentionally does not contain fallback entries... we want
@@ -440,7 +440,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0,!=14.0.0,!=14.1.0
+          - cupy>=14.0.1,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -450,11 +450,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
+              - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
+              - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
   depends_on_libnvforest:
     common:
       - output_types: conda

--- a/python/nvforest/pyproject.toml
+++ b/python/nvforest/pyproject.toml
@@ -28,9 +28,9 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0a0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
+    "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "libnvforest==26.8.*,>=0.0.0a0",
-    "numpy>=1.23,<3.0a0",
+    "numpy>=2.0,<3.0a0",
     "pylibraft==26.8.*,>=0.0.0a0",
     "scikit-learn>=1.5",
     "treelite>=4.6.1,<5.0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/279

RAPIDS is taking on requirements `cupy>=14.0.1,!=14.1.0` and `numpy>=2.0`. Wheel dependencies on `cupy-cuda12x` and `cupy-cuda13x` now use the `[ctk]` extra.

See the linked issue for details.