### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - ccache
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - ccache
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - ccache
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - ccache
 - click
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - c-compiler
 - clang-tools==15.0.7
 - clang==15.0.7
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api

--- a/conda/environments/clang_tidy_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-133_arch-x86_64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - c-compiler
 - clang-tools==15.0.7
 - clang==15.0.7
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api

--- a/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api

--- a/conda/environments/cpp_all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-133_arch-x86_64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api

--- a/conda/recipes/libnvforest/conda_build_config.yaml
+++ b/conda/recipes/libnvforest/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "=2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 treelite_version:
   - ">=4.7.0,<5.0.0"

--- a/conda/recipes/nvforest/conda_build_config.yaml
+++ b/conda/recipes/nvforest/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -199,7 +199,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=4.0,<4.4
           - ninja
       - output_types: conda
         packages:

--- a/python/libnvforest/pyproject.toml
+++ b/python/libnvforest/pyproject.toml
@@ -63,7 +63,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",
     "ninja",

--- a/python/nvforest/pyproject.toml
+++ b/python/nvforest/pyproject.toml
@@ -91,7 +91,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cuda-bindings>=13.0.1,<14.0",
     "cython>=3.0.0",
     "libnvforest==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
