### PR TITLE
Validate inference chunk sizes

### DIFF
--- a/cpp/include/nvforest/detail/infer.hpp
+++ b/cpp/include/nvforest/detail/infer.hpp
@@ -9,6 +9,7 @@
 #include <nvforest/detail/raft_proto/cuda_stream.hpp>
 #include <nvforest/detail/raft_proto/device_id.hpp>
 #include <nvforest/detail/raft_proto/device_type.hpp>
+#include <nvforest/detail/validate_chunk_size.hpp>
 #include <nvforest/exceptions.hpp>
 #include <nvforest/infer_kind.hpp>
 
@@ -67,6 +68,8 @@ void infer(forest_t const& forest,
            raft_proto::device_id<D> device                            = raft_proto::device_id<D>{},
            raft_proto::cuda_stream stream                             = raft_proto::cuda_stream{})
 {
+  validate_chunk_size(specified_chunk_size, D);
+
   if (vector_output == nullptr) {
     if (categorical_data == nullptr) {
       if (!has_categorical_nodes) {

--- a/cpp/include/nvforest/detail/validate_chunk_size.hpp
+++ b/cpp/include/nvforest/detail/validate_chunk_size.hpp
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <nvforest/detail/index_type.hpp>
+#include <nvforest/detail/raft_proto/device_type.hpp>
+#include <nvforest/exceptions.hpp>
+
+#include <optional>
+
+namespace nvforest::detail {
+
+inline void validate_chunk_size(std::optional<index_type> specified_chunk_size,
+                                raft_proto::device_type device_type)
+{
+  if (!specified_chunk_size.has_value()) { return; }
+
+  auto const chunk_size = specified_chunk_size.value();
+  if (chunk_size == 0) { throw runtime_error("Chunk size must be greater than zero"); }
+
+  if (device_type == raft_proto::device_type::gpu &&
+      (chunk_size > 32 || (chunk_size & (chunk_size - 1)) != 0)) {
+    throw runtime_error("GPU chunk size must be a power of two between 1 and 32");
+  }
+}
+
+}  // namespace nvforest::detail

--- a/cpp/include/nvforest/forest_model.hpp
+++ b/cpp/include/nvforest/forest_model.hpp
@@ -9,6 +9,7 @@
 #include <nvforest/detail/raft_proto/cuda_check.hpp>
 #include <nvforest/detail/raft_proto/gpu_support.hpp>
 #include <nvforest/detail/raft_proto/handle.hpp>
+#include <nvforest/detail/validate_chunk_size.hpp>
 #include <nvforest/infer_kind.hpp>
 
 #ifdef NVFOREST_ENABLE_GPU
@@ -188,6 +189,8 @@ struct forest_model {
                infer_kind predict_type                        = infer_kind::default_kind,
                std::optional<index_type> specified_chunk_size = std::nullopt)
   {
+    detail::validate_chunk_size(specified_chunk_size, memory_type());
+
     std::visit(
       [this, predict_type, &handle, &output, &input, &specified_chunk_size](
         auto&& concrete_forest) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ ConfigureTest(NAME HOST_BUFFER_TEST raft_proto/buffer.cpp)
 ConfigureTest(NAME DEVICE_BUFFER_TEST raft_proto/buffer.cu)
 ConfigureTest(NAME FOREST_TRAVERSAL_TEST forest/traversal_forest.cpp)
 ConfigureTest(NAME TREELITE_TRAVERSAL_TEST forest/treelite_traversal.cpp)
+ConfigureTest(NAME INFERENCE_TEST inference/validate_chunk_size.cpp)
 ConfigureTest(NAME TREELITE_IMPORTER_TEST treelite_importer.cpp treelite_importer_invalid_inputs.cpp
                                           decision_forest_builder_invalid_inputs.cpp)
 

--- a/cpp/tests/inference/validate_chunk_size.cpp
+++ b/cpp/tests/inference/validate_chunk_size.cpp
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nvforest/detail/validate_chunk_size.hpp>
+#include <nvforest/exceptions.hpp>
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+namespace nvforest::detail {
+namespace {
+
+TEST(ValidateChunkSize, AcceptsValidGpuValues)
+{
+  for (auto chunk_size : {1, 2, 4, 8, 16, 32}) {
+    EXPECT_NO_THROW(validate_chunk_size(chunk_size, raft_proto::device_type::gpu));
+  }
+  EXPECT_NO_THROW(validate_chunk_size(std::nullopt, raft_proto::device_type::gpu));
+}
+
+TEST(ValidateChunkSize, RejectsInvalidGpuValues)
+{
+  for (auto chunk_size : {0, 3, 6, 17, 33}) {
+    EXPECT_THROW(validate_chunk_size(chunk_size, raft_proto::device_type::gpu), runtime_error);
+  }
+}
+
+TEST(ValidateChunkSize, AcceptsAnyPositiveCpuValue)
+{
+  for (auto chunk_size : {1, 2, 3, 6, 17, 33, 512}) {
+    EXPECT_NO_THROW(validate_chunk_size(chunk_size, raft_proto::device_type::cpu));
+  }
+  EXPECT_NO_THROW(validate_chunk_size(std::nullopt, raft_proto::device_type::cpu));
+}
+
+TEST(ValidateChunkSize, RejectsZeroForCpu)
+{
+  EXPECT_THROW(validate_chunk_size(0, raft_proto::device_type::cpu), runtime_error);
+}
+
+}  // namespace
+}  // namespace nvforest::detail

--- a/python/nvforest/nvforest/detail/forest_inference.pyx
+++ b/python/nvforest/nvforest/detail/forest_inference.pyx
@@ -46,6 +46,10 @@ def _validate_chunk_size(chunk_size, device):
 
     if chunk_size <= 0:
         raise ValueError("chunk_size must be greater than zero")
+    if chunk_size > 0xFFFFFFFF:
+        raise ValueError(
+            "chunk_size must fit within a 32-bit unsigned integer"
+        )
     if device == "gpu" and chunk_size not in (1, 2, 4, 8, 16, 32):
         raise ValueError(
             "GPU chunk_size must be a power of two between 1 and 32"

--- a/python/nvforest/nvforest/detail/forest_inference.pyx
+++ b/python/nvforest/nvforest/detail/forest_inference.pyx
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from operator import index as index_operator
 from typing import Optional, Union
 
 import numpy as np
@@ -32,6 +33,24 @@ from nvforest.detail.treelite cimport (
     TreeliteFreeModel,
     TreeliteModelHandle,
 )
+
+
+def _validate_chunk_size(chunk_size, device):
+    if chunk_size is None:
+        return None
+
+    try:
+        chunk_size = index_operator(chunk_size)
+    except TypeError:
+        raise TypeError("chunk_size must be an integer or None") from None
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    if device == "gpu" and chunk_size not in (1, 2, 4, 8, 16, 32):
+        raise ValueError(
+            "GPU chunk_size must be a power of two between 1 and 32"
+        )
+    return chunk_size
 
 
 cdef extern from "nvforest/forest_model.hpp" namespace "nvforest" nogil:
@@ -194,6 +213,7 @@ cdef class ForestInference_impl():
         cdef infer_kind infer_type_enum
         cdef optional[uint32_t] chunk_specification
 
+        chunk_size = _validate_chunk_size(chunk_size, self.device)
         n_rows = X.shape[0]
         model_dtype = self.get_dtype()
 
@@ -285,6 +305,7 @@ class ForestInferenceImpl:
     ):
         # Assumption: The caller needs to pass in correct (device, device_id) pair
         # This function will not contain any logic for auto-detecting device.
+        default_chunk_size = _validate_chunk_size(default_chunk_size, device)
         self.handle = Handle() if handle is None else handle
         self._layout = layout
         self.precision = precision
@@ -373,7 +394,12 @@ class ForestInferenceImpl:
         self._validate_input_dims(X)
         # Returns probabilities if the model is a classifier
         return self.impl.predict(
-            X, chunk_size=(chunk_size or self.default_chunk_size)
+            X,
+            chunk_size=(
+                chunk_size
+                if chunk_size is not None
+                else self.default_chunk_size
+            ),
         )
 
     def predict_per_tree(
@@ -383,7 +409,9 @@ class ForestInferenceImpl:
         chunk_size: Optional[int] = None,
     ) -> DataType:
         self._validate_input_dims(X)
-        chunk_size = (chunk_size or self.default_chunk_size)
+        chunk_size = (
+            chunk_size if chunk_size is not None else self.default_chunk_size
+        )
         return self.impl.predict(
             X, predict_type="per_tree", chunk_size=chunk_size
         )
@@ -395,7 +423,9 @@ class ForestInferenceImpl:
         chunk_size: Optional[int] = None,
     ) -> DataType:
         self._validate_input_dims(X)
-        chunk_size = (chunk_size or self.default_chunk_size)
+        chunk_size = (
+            chunk_size if chunk_size is not None else self.default_chunk_size
+        )
         return self.impl.predict(
             X, predict_type="leaf_id", chunk_size=chunk_size
         )

--- a/python/nvforest/tests/test_nvforest.py
+++ b/python/nvforest/tests/test_nvforest.py
@@ -483,7 +483,7 @@ def test_valid_chunk_size(
 
 
 @pytest.mark.parametrize("use_default", (False, True))
-@pytest.mark.parametrize("chunk_size", [3, 6, 17, 33])
+@pytest.mark.parametrize("chunk_size", [3, 6, 17, 33, 2**32 - 1])
 def test_valid_non_power_of_two_cpu_chunk_size(
     use_default, chunk_size, small_classifier_and_preds
 ):
@@ -507,6 +507,7 @@ def test_valid_non_power_of_two_cpu_chunk_size(
     [
         ("cpu", 0),
         ("cpu", -1),
+        ("cpu", 2**32),
         ("gpu", 0),
         ("gpu", -1),
         ("gpu", 3),
@@ -532,6 +533,7 @@ def test_invalid_chunk_size(device, chunk_size, small_classifier_and_preds):
     [
         ("cpu", 0),
         ("cpu", -1),
+        ("cpu", 2**32),
         ("gpu", 0),
         ("gpu", -1),
         ("gpu", 3),
@@ -552,6 +554,19 @@ def test_invalid_default_chunk_size(
             device=device,
             default_chunk_size=chunk_size,
         )
+
+
+@pytest.mark.parametrize("chunk_size", [1.5, "4"])
+def test_non_integer_chunk_size(chunk_size, small_classifier_and_preds):
+    model_path, model_type, X, _ = small_classifier_and_preds
+    fm = nvforest.load_model(
+        model_path,
+        model_type=model_type,
+        device="cpu",
+    )
+
+    with pytest.raises(TypeError, match="chunk_size"):
+        fm.predict(X, chunk_size=chunk_size)
 
 
 @pytest.mark.parametrize("device", ("cpu", "gpu"))

--- a/python/nvforest/tests/test_nvforest.py
+++ b/python/nvforest/tests/test_nvforest.py
@@ -462,6 +462,99 @@ def test_chunk_size(chunk_size, small_classifier_and_preds):
 
 
 @pytest.mark.parametrize("device", ("cpu", "gpu"))
+@pytest.mark.parametrize("use_default", (False, True))
+@pytest.mark.parametrize("chunk_size", [1, 2, 4, 8, 16, 32])
+def test_valid_chunk_size(
+    device, use_default, chunk_size, small_classifier_and_preds
+):
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
+    fm = nvforest.load_model(
+        model_path,
+        model_type=model_type,
+        device=device,
+        default_chunk_size=chunk_size if use_default else None,
+    )
+
+    kwargs = {} if use_default else {"chunk_size": chunk_size}
+    nvforest_preds = _get_numpy_array(
+        fm.predict_proba(X[:1], **kwargs)
+    ).squeeze()
+    np.testing.assert_almost_equal(nvforest_preds, xgb_preds[0])
+
+
+@pytest.mark.parametrize("use_default", (False, True))
+@pytest.mark.parametrize("chunk_size", [3, 6, 17, 33])
+def test_valid_non_power_of_two_cpu_chunk_size(
+    use_default, chunk_size, small_classifier_and_preds
+):
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
+    fm = nvforest.load_model(
+        model_path,
+        model_type=model_type,
+        device="cpu",
+        default_chunk_size=chunk_size if use_default else None,
+    )
+
+    kwargs = {} if use_default else {"chunk_size": chunk_size}
+    nvforest_preds = _get_numpy_array(
+        fm.predict_proba(X[:1], **kwargs)
+    ).squeeze()
+    np.testing.assert_almost_equal(nvforest_preds, xgb_preds[0])
+
+
+@pytest.mark.parametrize(
+    "device,chunk_size",
+    [
+        ("cpu", 0),
+        ("cpu", -1),
+        ("gpu", 0),
+        ("gpu", -1),
+        ("gpu", 3),
+        ("gpu", 6),
+        ("gpu", 17),
+        ("gpu", 33),
+    ],
+)
+def test_invalid_chunk_size(device, chunk_size, small_classifier_and_preds):
+    model_path, model_type, X, _ = small_classifier_and_preds
+    fm = nvforest.load_model(
+        model_path,
+        model_type=model_type,
+        device=device,
+    )
+
+    with pytest.raises(ValueError, match="chunk_size"):
+        fm.predict(X, chunk_size=chunk_size)
+
+
+@pytest.mark.parametrize(
+    "device,chunk_size",
+    [
+        ("cpu", 0),
+        ("cpu", -1),
+        ("gpu", 0),
+        ("gpu", -1),
+        ("gpu", 3),
+        ("gpu", 6),
+        ("gpu", 17),
+        ("gpu", 33),
+    ],
+)
+def test_invalid_default_chunk_size(
+    device, chunk_size, small_classifier_and_preds
+):
+    model_path, model_type, _, _ = small_classifier_and_preds
+
+    with pytest.raises(ValueError, match="chunk_size"):
+        nvforest.load_model(
+            model_path,
+            model_type=model_type,
+            device=device,
+            default_chunk_size=chunk_size,
+        )
+
+
+@pytest.mark.parametrize("device", ("cpu", "gpu"))
 def test_output_args(device, small_classifier_and_preds):
     model_path, model_type, X, xgb_preds = small_classifier_and_preds
     fm = nvforest.load_model(model_path, model_type=model_type, device=device)


### PR DESCRIPTION
GPU inference supports chunk sizes that are powers of two from 1 to 32, but workspace and grid calculations previously used the requested value before dispatch selected a kernel specialization. A chunk size of 3 could therefore allocate space for three rows and launch a kernel that processes four. Zero also reached division by zero, and negative Python values could wrap during conversion to `uint32_t`.

Validate chunk sizes before inference arithmetic and before Python converts them to an unsigned integer. GPU inference now accepts only powers of two from 1 to 32, while CPU inference accepts any positive value. Constructor-level defaults are validated when the model is created.

Adds C++ and Python regression coverage for valid and invalid values, per-call overrides, constructor defaults, and CPU/GPU behavior.
