### PR TITLE
Fix shared memory buffer allocation and synchronization

### DIFF
--- a/cpp/include/nvforest/detail/infer_kernel/shared_memory_buffer.cuh
+++ b/cpp/include/nvforest/detail/infer_kernel/shared_memory_buffer.cuh
@@ -81,7 +81,8 @@ struct shared_memory_buffer {
 
   /* If possible, fill the next element_count elements with given value. If
    * there is not enough room, the fill is not performed. Return a pointer to
-   * the start of the desired data if the fill was possible or else nullptr. */
+   * the start of the desired data if the fill was possible, or else the
+   * provided fallback buffer (nullptr by default). */
   template <typename T>
   __device__ auto* fill(index_type element_count, T value = T{}, T* fallback_buffer = nullptr)
   {

--- a/cpp/include/nvforest/detail/infer_kernel/shared_memory_buffer.cuh
+++ b/cpp/include/nvforest/detail/infer_kernel/shared_memory_buffer.cuh
@@ -19,7 +19,11 @@ namespace nvforest {
  */
 struct shared_memory_buffer {
   __device__ shared_memory_buffer(std::byte* buffer = nullptr, index_type size = index_type{})
-    : data{buffer}, total_size{size}, remaining_data{buffer}, remaining_size{size}
+    : data{buffer},
+      total_size{size},
+      remaining_data{buffer},
+      remaining_size{size},
+      requires_sync{false}
   {
   }
 
@@ -34,25 +38,23 @@ struct shared_memory_buffer {
                         index_type col_count,
                         index_type row_pad = index_type{})
   {
-    auto* dest        = reinterpret_cast<std::remove_const_t<T>*>(remaining_data);
-    auto source_count = row_count * col_count;
-    auto dest_count   = row_count * (col_count + row_pad);
+    auto const row_width          = std::size_t{col_count} + std::size_t{row_pad};
+    auto const available_elements = std::size_t{remaining_size} / sizeof(T);
+    if (row_count != 0 && row_width > available_elements / row_count) { return source; }
 
-    auto copy_data = (dest_count * sizeof(T) <= remaining_size);
-
-    source_count *= copy_data;
-    for (auto i = threadIdx.x; i < source_count; i += blockDim.x) {
+    auto* dest              = reinterpret_cast<std::remove_const_t<T>*>(remaining_data);
+    auto const source_count = std::size_t{row_count} * std::size_t{col_count};
+    auto const dest_count   = std::size_t{row_count} * row_width;
+    for (auto i = std::size_t{threadIdx.x}; i < source_count; i += blockDim.x) {
       dest[i + row_pad * (i / col_count)] = source[i];
     }
 
-    auto* result  = copy_data ? static_cast<T*>(dest) : source;
-    requires_sync = requires_sync || copy_data;
-
-    auto offset = dest_count * index_type(sizeof(T));
+    auto const offset = dest_count * sizeof(T);
     remaining_data += offset;
-    remaining_size -= offset;
+    remaining_size -= index_type(offset);
+    requires_sync = requires_sync || source_count != 0;
 
-    return result;
+    return static_cast<T*>(dest);
   }
 
   /* If possible, copy the given number of elements from source to the end of this buffer
@@ -62,22 +64,19 @@ struct shared_memory_buffer {
   template <typename T>
   __device__ auto* copy(T* source, index_type element_count)
   {
+    if (std::size_t{element_count} > std::size_t{remaining_size} / sizeof(T)) { return source; }
+
     auto* dest = reinterpret_cast<std::remove_const_t<T>*>(remaining_data);
-
-    auto copy_data = (element_count * index_type(sizeof(T)) <= remaining_size);
-
-    element_count *= copy_data;
-    for (auto i = threadIdx.x; i < element_count; i += blockDim.x) {
+    for (auto i = std::size_t{threadIdx.x}; i < element_count; i += blockDim.x) {
       dest[i] = source[i];
     }
-    auto* result  = copy_data ? static_cast<T*>(dest) : source;
-    requires_sync = requires_sync || copy_data;
 
-    auto offset = element_count * index_type(sizeof(T));
+    auto const offset = std::size_t{element_count} * sizeof(T);
     remaining_data += offset;
-    remaining_size -= offset;
+    remaining_size -= index_type(offset);
+    requires_sync = requires_sync || element_count != 0;
 
-    return result;
+    return static_cast<T*>(dest);
   }
 
   /* If possible, fill the next element_count elements with given value. If
@@ -86,23 +85,21 @@ struct shared_memory_buffer {
   template <typename T>
   __device__ auto* fill(index_type element_count, T value = T{}, T* fallback_buffer = nullptr)
   {
+    if (std::size_t{element_count} > std::size_t{remaining_size} / sizeof(T)) {
+      return fallback_buffer;
+    }
+
     auto* dest = reinterpret_cast<std::remove_const_t<T>*>(remaining_data);
-
-    auto copy_data = (element_count * index_type(sizeof(T)) <= remaining_size);
-
-    element_count *= copy_data;
-    for (auto i = threadIdx.x; i < element_count; i += blockDim.x) {
+    for (auto i = std::size_t{threadIdx.x}; i < element_count; i += blockDim.x) {
       dest[i] = value;
     }
 
-    auto* result  = copy_data ? static_cast<T*>(dest) : fallback_buffer;
-    requires_sync = requires_sync || copy_data;
-
-    auto offset = element_count * index_type(sizeof(T));
+    auto const offset = std::size_t{element_count} * sizeof(T);
     remaining_data += offset;
-    remaining_size -= offset;
+    remaining_size -= index_type(offset);
+    requires_sync = requires_sync || element_count != 0;
 
-    return result;
+    return static_cast<T*>(dest);
   }
 
   /* Clear all stored data and return a pointer to the beginning of available
@@ -111,6 +108,7 @@ struct shared_memory_buffer {
   {
     remaining_size = total_size;
     remaining_data = data;
+    requires_sync  = false;
     return remaining_data;
   }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ endfunction()
 ConfigureTest(NAME HOST_BUFFER_TEST raft_proto/buffer.cpp)
 ConfigureTest(NAME DEVICE_BUFFER_TEST raft_proto/buffer.cu)
 ConfigureTest(NAME FOREST_TRAVERSAL_TEST forest/traversal_forest.cpp)
+ConfigureTest(NAME SHARED_MEMORY_BUFFER_TEST infer_kernel/shared_memory_buffer.cu)
 ConfigureTest(NAME TREELITE_TRAVERSAL_TEST forest/treelite_traversal.cpp)
 ConfigureTest(NAME TREELITE_IMPORTER_TEST treelite_importer.cpp treelite_importer_invalid_inputs.cpp
                                           decision_forest_builder_invalid_inputs.cpp)

--- a/cpp/tests/infer_kernel/shared_memory_buffer.cu
+++ b/cpp/tests/infer_kernel/shared_memory_buffer.cu
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nvforest/detail/infer_kernel/shared_memory_buffer.cuh>
+#include <nvforest/detail/raft_proto/buffer.hpp>
+#include <nvforest/detail/raft_proto/cuda_check.hpp>
+#include <nvforest/detail/raft_proto/cuda_stream.hpp>
+#include <nvforest/detail/raft_proto/device_type.hpp>
+#include <nvforest/detail/utils.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+namespace nvforest {
+namespace {
+
+struct allocation_result {
+  bool copied_to_shared;
+  int copy_value;
+  index_type remaining_after_copy;
+  bool subsequent_fill_succeeded;
+  index_type remaining_after_fill;
+  int fill_value;
+};
+
+NVFOREST_KERNEL void check_2d_allocation(int* source,
+                                         allocation_result* result,
+                                         index_type row_count,
+                                         index_type col_count,
+                                         index_type row_pad,
+                                         index_type shared_mem_size)
+{
+  extern __shared__ std::byte shared_mem[];
+  auto buffer               = shared_memory_buffer{shared_mem, shared_mem_size};
+  auto* copy_result         = buffer.copy(source, row_count, col_count, row_pad);
+  auto remaining_after_copy = buffer.remaining();
+  auto* fill_result         = buffer.fill<int>(1, 7);
+  buffer.sync();
+
+  if (threadIdx.x == 0) {
+    result->copied_to_shared          = copy_result != source;
+    result->copy_value                = copy_result[0];
+    result->remaining_after_copy      = remaining_after_copy;
+    result->subsequent_fill_succeeded = fill_result != nullptr;
+    result->remaining_after_fill      = buffer.remaining();
+    result->fill_value                = fill_result == nullptr ? 0 : fill_result[0];
+  }
+}
+
+auto run_2d_allocation(index_type row_count,
+                       index_type col_count,
+                       index_type row_pad,
+                       index_type shared_mem_size,
+                       std::size_t source_size)
+{
+  auto source_data = std::vector<int>(source_size, 42);
+  auto source =
+    raft_proto::buffer<int>{source_data.begin(), source_data.end(), raft_proto::device_type::gpu};
+  auto result = raft_proto::buffer<allocation_result>{1, raft_proto::device_type::gpu};
+
+  check_2d_allocation<<<1, 32, shared_mem_size>>>(
+    source.data(), result.data(), row_count, col_count, row_pad, shared_mem_size);
+  raft_proto::cuda_check(cudaGetLastError());
+
+  auto result_data = allocation_result{};
+  auto host_result =
+    raft_proto::buffer<allocation_result>{&result_data, 1, raft_proto::device_type::cpu};
+  raft_proto::copy<true>(host_result, result);
+  raft_proto::cuda_check(cudaStreamSynchronize(raft_proto::cuda_stream{}));
+  return result_data;
+}
+
+TEST(SharedMemoryBuffer, CopiesAllocationThatFitsExactly)
+{
+  auto const result = run_2d_allocation(2, 2, 0, 4 * sizeof(int), 4);
+
+  EXPECT_TRUE(result.copied_to_shared);
+  EXPECT_EQ(result.copy_value, 42);
+  EXPECT_EQ(result.remaining_after_copy, 0);
+  EXPECT_FALSE(result.subsequent_fill_succeeded);
+  EXPECT_EQ(result.remaining_after_fill, 0);
+}
+
+TEST(SharedMemoryBuffer, PreservesStateIfAllocationIsOneByteTooLarge)
+{
+  auto constexpr shared_mem_size = 4 * sizeof(int) - 1;
+  auto const result              = run_2d_allocation(2, 2, 0, shared_mem_size, 4);
+
+  EXPECT_FALSE(result.copied_to_shared);
+  EXPECT_EQ(result.remaining_after_copy, shared_mem_size);
+  EXPECT_TRUE(result.subsequent_fill_succeeded);
+  EXPECT_EQ(result.remaining_after_fill, shared_mem_size - sizeof(int));
+  EXPECT_EQ(result.fill_value, 7);
+}
+
+TEST(SharedMemoryBuffer, RejectsWideInputWithoutOverflowingSizeCalculation)
+{
+  auto constexpr shared_mem_size = 16 * sizeof(int);
+  auto const result              = run_2d_allocation(1, 100'000, 0, shared_mem_size, 100'000);
+
+  EXPECT_FALSE(result.copied_to_shared);
+  EXPECT_EQ(result.remaining_after_copy, shared_mem_size);
+  EXPECT_TRUE(result.subsequent_fill_succeeded);
+  EXPECT_EQ(result.remaining_after_fill, shared_mem_size - sizeof(int));
+}
+
+TEST(SharedMemoryBuffer, RejectsDimensionsWhoseProductWouldOverflow)
+{
+  auto constexpr max_index       = std::numeric_limits<index_type>::max();
+  auto constexpr shared_mem_size = 16 * sizeof(int);
+  auto const result = run_2d_allocation(max_index, max_index, max_index, shared_mem_size, 1);
+
+  EXPECT_FALSE(result.copied_to_shared);
+  EXPECT_EQ(result.remaining_after_copy, shared_mem_size);
+  EXPECT_TRUE(result.subsequent_fill_succeeded);
+  EXPECT_EQ(result.remaining_after_fill, shared_mem_size - sizeof(int));
+}
+
+NVFOREST_KERNEL void check_failed_copy_sync(int* source, unsigned int* completed_blocks)
+{
+  auto buffer = shared_memory_buffer{};
+  buffer.copy(source, index_type{1});
+  buffer.sync();
+  if (threadIdx.x == 0) { atomicAdd(completed_blocks, 1); }
+}
+
+TEST(SharedMemoryBuffer, RepeatedlySkipsSyncIfNoCopyOccurs)
+{
+  auto source_data = std::vector<int>{42};
+  auto source =
+    raft_proto::buffer<int>{source_data.begin(), source_data.end(), raft_proto::device_type::gpu};
+  auto completed_data = std::vector<unsigned int>{0};
+  auto completed      = raft_proto::buffer<unsigned int>{
+    completed_data.begin(), completed_data.end(), raft_proto::device_type::gpu};
+
+  auto constexpr launch_count = 1'000;
+  auto constexpr block_count  = 32;
+  for (auto i = 0; i < launch_count; ++i) {
+    check_failed_copy_sync<<<block_count, 128>>>(source.data(), completed.data());
+  }
+  raft_proto::cuda_check(cudaGetLastError());
+
+  auto host_completed = raft_proto::buffer<unsigned int>{
+    completed_data.data(), completed_data.size(), raft_proto::device_type::cpu};
+  raft_proto::copy<true>(host_completed, completed);
+  raft_proto::cuda_check(cudaStreamSynchronize(raft_proto::cuda_stream{}));
+  EXPECT_EQ(completed_data[0], launch_count * block_count);
+}
+
+}  // namespace
+}  // namespace nvforest


### PR DESCRIPTION
`shared_memory_buffer` previously read `requires_sync` before initialization. Since each CUDA thread has its own buffer object, threads could disagree about entering the conditional `__syncthreads()` and deadlock the block.

The two-dimensional copy path also advanced the allocator after an allocation failed. This could underflow the unsigned remaining-size counter and leave the buffer in an invalid state.

Initialize and reset the synchronization state, leave allocator state unchanged after failed operations, and use overflow-safe capacity checks before calculating byte offsets. Adds CUDA regression coverage for exact-fit and failed allocations, subsequent allocation recovery, wide inputs, overflowing dimensions, and repeated no-copy launches.
