### PR TITLE
enforce 'yamllint' checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,10 +13,11 @@ CMakeLists.txt @rapidsai/nvforest-cpp-codeowners
 **/cmake/      @rapidsai/nvforest-cpp-codeowners
 
 # CI code owners
-/.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
 /VERSION                 @rapidsai/ci-codeowners
 /.coderabbit.yaml        @rapidsai/ci-codeowners
+/.github/                @rapidsai/ci-codeowners
+/.yamllint.yaml          @rapidsai/ci-codeowners
 
 # packaging code owners
 /.pre-commit-config.yaml   @rapidsai/packaging-codeowners

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -74,14 +74,15 @@ jobs:
     with:
       files_yaml: |
         build_docs:
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
           - '!.pre-commit-config.yaml'
+          - '!.yamllint.yaml'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!SECURITY.md'
           - '!ci/release/update-version.sh'
           - '!**/*/agents.md'
-          - '!.coderabbit.yaml'
         test_cpp:
           - '**'
           - '!.coderabbit.yaml'
@@ -92,6 +93,7 @@ jobs:
           - '!.github/ops-bot.yaml'
           - '!.github/workflows/labeler.yml'
           - '!.pre-commit-config.yaml'
+          - '!.yamllint.yaml'
           - '!README.md'
           - '!SECURITY.md'
           - '!ci/build_python.sh'
@@ -115,6 +117,7 @@ jobs:
           - '!.github/ops-bot.yaml'
           - '!.github/workflows/labeler.yml'
           - '!.pre-commit-config.yaml'
+          - '!.yamllint.yaml'
           - '!README.md'
           - '!SECURITY.md'
           - '!ci/build_wheel*.sh'
@@ -136,6 +139,7 @@ jobs:
           - '!.github/ops-bot.yaml'
           - '!.github/workflows/labeler.yml'
           - '!.pre-commit-config.yaml'
+          - '!.yamllint.yaml'
           - '!README.md'
           - '!SECURITY.md'
           - '!ci/build_cpp.sh'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,129 +3,140 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v5.0.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-    - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.14.3
-      hooks:
-          - id: ruff-check
-            args: [--fix]
-          - id: ruff-format
-    - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-            files: python/.*
-            args: ["--settings-path", "python/nvforest/pyproject.toml"]
-    - repo: https://github.com/MarcoGorelli/cython-lint
-      rev: v0.16.6
-      hooks:
-          - id: cython-lint
-    - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: v20.1.8
-      hooks:
-          - id: clang-format
-            types_or: [c, c++, cuda]
-            args: ["-fallback-style=none", "-style=file", "-i"]
-    - repo: https://github.com/codespell-project/codespell
-      rev: v2.4.1
-      hooks:
-          - id: codespell
-            additional_dependencies: [tomli]
-            args: ["--toml", "pyproject.toml"]
-    - repo: local
-      hooks:
-          - id: no-deprecationwarning
-            name: no-deprecationwarning
-            description: 'Enforce that DeprecationWarning is not introduced (use FutureWarning instead)'
-            entry: '(category=|\s)DeprecationWarning[,)]'
-            language: pygrep
-            types_or: [python, cython]
-          - id: cmake-format
-            name: cmake-format
-            entry: ./cpp/scripts/run-cmake-format.sh cmake-format
-            language: python
-            types: [cmake]
-            # Note that pre-commit autoupdate does not update the versions
-            # of dependencies, so we'll have to update this manually.
-            additional_dependencies:
-              - cmakelang==0.6.13
-            verbose: true
-            require_serial: true
-          - id: cmake-lint
-            name: cmake-lint
-            entry: ./cpp/scripts/run-cmake-format.sh cmake-lint
-            language: python
-            types: [cmake]
-            # Note that pre-commit autoupdate does not update the versions
-            # of dependencies, so we'll have to update this manually.
-            additional_dependencies:
-              - cmakelang==0.6.13
-            verbose: true
-            require_serial: true
-          - id: no-import-in-pxd
-            name: no-import-in-pxd
-            description: "Don't use `import` in .pxd files, only `cimport` statements make sense here"
-            entry: '^import | import '
-            language: pygrep
-            files: "^.*.pxd$"
-          - id: include-check
-            name: include-check
-            entry: python cpp/scripts/include_checker.py
-            args:
-                - cpp/include
-                - cpp/src
-                - cpp/tests
-            pass_filenames: false
-            language: python
-    - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v1.6.0
-      hooks:
-        - id: verify-copyright
-          name: verify-copyright
-          args: [--fix, --spdx]
-          files: |
-            (?x)
-              [.](cmake|c|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|bat)$|
-              CMakeLists[.]txt$|
-              CMakeLists_standalone[.]txt$|
-              [.]flake8[.]cython$|
-              meta[.]yaml$|
-              ^[.]pre-commit-config[.]yaml$|
-              [.]flake8$|
-              pyproject[.]toml$|
-              recipe[.]yaml$|
-              Makefile$|
-              dependencies[.]yaml$|
-              pytest[.]ini$
-          exclude: |
-            (?x)^(
-              ci/build_docs[.]sh
-            )
-        - id: verify-alpha-spec
-        - id: verify-pyproject-license
-          # ignore the top-level pyproject.toml, which doesn't
-          # have or need a [project] table
-          exclude: |
-            (?x)
-              ^pyproject[.]toml$
-    - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.20.2
-      hooks:
-          - id: rapids-dependency-file-generator
-            args: ["--clean", "--warn-all", "--strict"]
-    - repo: https://github.com/shellcheck-py/shellcheck-py
-      rev: v0.11.0.1
-      hooks:
-        - id: shellcheck
-          args: ["--severity=warning"]
-    - repo: https://github.com/zizmorcore/zizmor-pre-commit
-      rev: v1.24.1
-      hooks:
-        - id: zizmor
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.3
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        files: python/.*
+        args: ["--settings-path", "python/nvforest/pyproject.toml"]
+  - repo: https://github.com/MarcoGorelli/cython-lint
+    rev: v0.16.6
+    hooks:
+      - id: cython-lint
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.8
+    hooks:
+      - id: clang-format
+        types_or: [c, c++, cuda]
+        args: ["-fallback-style=none", "-style=file", "-i"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
+  - repo: local
+    hooks:
+      - id: no-deprecationwarning
+        name: no-deprecationwarning
+        description: 'Enforce that DeprecationWarning is not introduced (use FutureWarning instead)'
+        entry: '(category=|\s)DeprecationWarning[,)]'
+        language: pygrep
+        types_or: [python, cython]
+      - id: cmake-format
+        name: cmake-format
+        entry: ./cpp/scripts/run-cmake-format.sh cmake-format
+        language: python
+        types: [cmake]
+        # Note that pre-commit autoupdate does not update the versions
+        # of dependencies, so we'll have to update this manually.
+        additional_dependencies:
+          - cmakelang==0.6.13
+        verbose: true
+        require_serial: true
+      - id: cmake-lint
+        name: cmake-lint
+        entry: ./cpp/scripts/run-cmake-format.sh cmake-lint
+        language: python
+        types: [cmake]
+        # Note that pre-commit autoupdate does not update the versions
+        # of dependencies, so we'll have to update this manually.
+        additional_dependencies:
+          - cmakelang==0.6.13
+        verbose: true
+        require_serial: true
+      - id: no-import-in-pxd
+        name: no-import-in-pxd
+        description: "Don't use `import` in .pxd files, only `cimport` statements make sense here"
+        entry: '^import | import '
+        language: pygrep
+        files: "^.*.pxd$"
+      - id: include-check
+        name: include-check
+        entry: python cpp/scripts/include_checker.py
+        args:
+          - cpp/include
+          - cpp/src
+          - cpp/tests
+        pass_filenames: false
+        language: python
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v1.6.0
+    hooks:
+      - id: verify-copyright
+        name: verify-copyright
+        args: [--fix, --spdx]
+        files: |
+          (?x)
+            [.](cmake|c|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|bat)$|
+            CMakeLists[.]txt$|
+            CMakeLists_standalone[.]txt$|
+            [.]flake8[.]cython$|
+            meta[.]yaml$|
+            ^[.]pre-commit-config[.]yaml$|
+            [.]flake8$|
+            pyproject[.]toml$|
+            recipe[.]yaml$|
+            Makefile$|
+            dependencies[.]yaml$|
+            pytest[.]ini$
+        exclude: |
+          (?x)^(
+            ci/build_docs[.]sh
+          )
+      - id: verify-alpha-spec
+      - id: verify-pyproject-license
+        # ignore the top-level pyproject.toml, which doesn't
+        # have or need a [project] table
+        exclude: |
+          (?x)
+            ^pyproject[.]toml$
+  - repo: https://github.com/rapidsai/dependency-file-generator
+    rev: v1.20.2
+    hooks:
+      - id: rapids-dependency-file-generator
+        args: ["--clean", "--warn-all", "--strict"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]
+        exclude: |
+          (?x)^(
+            [.]github/workflows/labeler[.]yml$|
+            conda/environments/.*|
+            cpp/[.]clang-format
+          )
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
 
 default_language_version:
-    python: python3
+  python: python3

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/conda/recipes/nvforest/recipe.yaml
+++ b/conda/recipes/nvforest/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 
@@ -10,7 +10,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   head_rev: '${{ git.head_rev(".")[:8] }}'
   py_abi_min: ${{ env.get("RAPIDS_PY_VERSION") }}
-  py_buildstring : ${{ py_abi_min | version_to_buildstring }}
+  py_buildstring: ${{ py_abi_min | version_to_buildstring }}
   py_runtime_latest: "3.14"
 
 package:
@@ -30,7 +30,7 @@ build:
   prefix_detection:
     # See https://github.com/rapidsai/build-planning/issues/160
     # Blanket ignore here as there are quite a few shared objects shipped in nvforest
-    ignore_binary_files: True
+    ignore_binary_files: true
   script:
     content: |
       ./build.sh nvforest -v

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -429,12 +429,12 @@ dependencies:
     specific:
       - output_types: [conda]
         matrices:
-        - matrix:
-            py: "3.11"
-          packages: []
-        - matrix:
-          packages:
-            - rapids-xgboost==26.10.*,>=0.0.0a0
+          - matrix:
+              py: "3.11"
+            packages: []
+          - matrix:
+            packages:
+              - rapids-xgboost==26.10.*,>=0.0.0a0
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here. My primary motivation is to catch correctness issues in `dependencies.yaml` files, like duplicate entries silently resolving to the last one or indentation mistakes leading to filters being ignored.

But this also has some side benefits for consistency, which makes it a bit easier to write automation.