### PR TITLE
Replace `rapids-xgboost` with `xgboost` in the CI.

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -113,7 +113,6 @@ DEPENDENCIES=(
   libraft-headers
   librmm
   pylibraft
-  rapids-xgboost
   rmm
 )
 for DEP in "${DEPENDENCIES[@]}"; do

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 ## Usage

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,6 +10,7 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -43,7 +44,6 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0
-- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -36,7 +36,6 @@ dependencies:
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0.dev0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0
 - scikit-learn>=1.5
 - sphinx
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -36,7 +36,6 @@ dependencies:
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0.dev0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0
 - scikit-learn>=1.5
 - sphinx
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,6 +10,7 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -43,7 +44,6 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0
-- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,6 +10,7 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -43,7 +44,6 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0
-- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -36,7 +36,6 @@ dependencies:
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0.dev0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0
 - scikit-learn>=1.5
 - sphinx
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,6 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,6 +10,7 @@ dependencies:
 - ccache
 - click
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -43,7 +44,6 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0
-- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -36,7 +36,6 @@ dependencies:
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0.dev0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0
 - scikit-learn>=1.5
 - sphinx
@@ -44,6 +43,7 @@ dependencies:
 - sphinx-markdown-tables
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -434,7 +434,7 @@ dependencies:
             packages: []
           - matrix:
             packages:
-              - rapids-xgboost==26.10.*,>=0.0.0a0
+              - xgboost>=3.3.0
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -434,7 +434,7 @@ dependencies:
             packages: []
           - matrix:
             packages:
-              - xgboost>=3.3.0
+              - conda-forge::xgboost>=3.3.0
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -434,7 +434,7 @@ dependencies:
             packages: []
           - matrix:
             packages:
-              - conda-forge::xgboost>=3.3.0
+              - xgboost>=3.3.0
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:


### PR DESCRIPTION
The CI will continue to install XGBoost from the rapidsai channel until the package is removed. See https://github.com/rapidsai/nvforest/pull/185#discussion_r3708386532