### PR TITLE
X-ORG-183: Enable docs version picker

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,6 +126,10 @@ html_theme_options = {
     "show_toc_level": 1,
     "navbar_align": "right",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/nvforest/versions.json",
+        "version_match": version,
+    },
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is execfile()d with the current directory set to its


### PR DESCRIPTION
Contributes to #183 

Let's enable the docs version picker.

N.B. I will backport this to 26.08 after the release to ensure it goes live for those docs.