### PR TITLE
Backport #187: Enable docs version picker

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is execfile()d with the current directory set to its
@@ -126,6 +126,10 @@ html_theme_options = {
     "show_toc_level": 1,
     "navbar_align": "right",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/nvforest/versions.json",
+        "version_match": version,
+    },
 }
 
 


### PR DESCRIPTION
Backport of #187, contributing to #183 for the 26.08 release.