### PR TITLE
X-ORG-183: publish-api-docs version-map uses vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,7 +114,7 @@ jobs:
     with:
       docs-projects: nvforest
       dry-run: false
-      version-map: '{"26.04": "legacy", "26.06": "stable"}'
+      version-map: ${{ vars.VERSION_MAP }}
   upload-conda:
     needs: [cpp-build, python-build]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -329,7 +329,7 @@ jobs:
     with:
       docs-projects: nvforest
       dry-run: true
-      version-map: '{"26.04": "legacy", "26.06": "stable"}'
+      version-map: ${{ vars.VERSION_MAP }}
   wheel-build-libnvforest:
     needs: [build-details, checks]
     permissions:


### PR DESCRIPTION
Contributes to #183  

Replace the (currently unused) hard-coded `version-map` with one we can set via `vars`.

This decouples updating the `versions.json` that powers the docs version switcher from code changes, making the docs release process simpler.

N.B. I'll be updating the docs publishing shared workflow to use this version map, but it currently doesn't.