### PR TITLE
Enable public docs features in CI

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,6 +114,7 @@ todo_include_todos = False
 html_theme = "nvidia_sphinx_theme"
 
 html_theme_options = {
+    "public_docs_features": os.environ.get("CI") == "true",
     "external_links": [],
     "icon_links": [
         {


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/319

Enable the Sphinx theme's `public_docs_features` option when `CI=true`, while leaving local documentation builds unchanged.
