### PR TITLE
Add scheduled Lychee link check

### DIFF
--- a/.github/workflows/link-checks.yaml
+++ b/.github/workflows/link-checks.yaml
@@ -1,0 +1,49 @@
+name: Link checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every Monday, Wednesday, and Friday at 08:00 UTC.
+    - cron: "0 8 * * 1,3,5"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Restore lychee cache
+        id: restore-lychee-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: lychee-${{ github.ref_name }}-
+      - name: List tracked files
+        run: git ls-files '*.md' '*.html' '*.rst' > "${RUNNER_TEMP}/lychee-files"
+      - name: Check links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --config .lychee.toml
+            --no-progress
+            --files-from "${{ runner.temp }}/lychee-files"
+          fail: true
+          failIfEmpty: true
+      - name: Save lychee cache
+        if: always()
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-lychee-cache.outputs.cache-primary-key }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,13 @@ jobs:
           repo: ${{ github.repository }}
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
           max-days-without-success: 7
+      - name: Check if link checks are passing
+        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
+        with:
+          repo: ${{ github.repository }}
+          target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+          workflow-id: link-checks.yaml
+          max-days-without-success: 14
   changed-files:
     needs: telemetry-setup
     permissions:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,14 @@
+cache = true
+max_cache_age = "3d"
+max_concurrency = 8
+max_retries = 3
+retry_wait_time = 2
+
+# Doxygen resolves modules.html and $relpath placeholders during generation.
+exclude = ['modules\.html$', '\$relpath']
+exclude_path = [
+  # Historical links are not maintained.
+  '(^|/)CHANGELOG\.md$',
+  # Package READMEs are symlinks whose relative links resolve from the repository root.
+  '^python/(libnvforest|nvforest)/README\.md$',
+]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We welcome contributions. For guidelines and how to get started, see the [RAPIDS
 
 ## Contact
 
-Find out more on the [RAPIDS site](https://rapids.ai/community.html).
+Find out more: [CUDA-X for Data Science](https://developer.nvidia.com/topics/ai/data-science/cuda-x-for-data-science)
 
 ## Open GPU Data Science
 


### PR DESCRIPTION
Adds a cached Lychee workflow that checks Markdown, HTML, and reStructuredText links every Monday, Wednesday, and Friday. Pull request CI starts failing after 14 days without a successful link check.

Modeled after https://github.com/rapidsai/rmm/pull/2532

Example run: https://github.com/chyunsu3/nvforest/actions/runs/33471974909/job/99743405587