### PR TITLE
Discover CMake packages installed by wheels

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -23,11 +23,20 @@ include(rapids-cpm)
 include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
+include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
 
 project(
   NVForest
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX)
+
+# Find CMake packages provided by installed wheels.
+find_package(Python COMPONENTS Interpreter)
+if(Python_FOUND)
+  rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
+  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+  list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})
+endif()
 
 # Write the version header
 rapids_cmake_write_version_file(include/nvforest/version_config.hpp)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -23,7 +23,6 @@ include(rapids-cpm)
 include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
-include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
 
 project(
   NVForest
@@ -33,6 +32,7 @@ project(
 # Find CMake packages provided by installed wheels.
 find_package(Python COMPONENTS Interpreter)
 if(Python_FOUND)
+  include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
   rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
   list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})

--- a/python/libnvforest/CMakeLists.txt
+++ b/python/libnvforest/CMakeLists.txt
@@ -17,6 +17,9 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX CUDA)
 
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+
 # Check if nvForest is already available. If so, it is the user's responsibility to ensure that the CMake package is
 # also available at build time of the Python nvForest package.
 find_package(nvforest "${RAPIDS_VERSION}")

--- a/python/nvforest/CMakeLists.txt
+++ b/python/nvforest/CMakeLists.txt
@@ -20,6 +20,9 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES ${language_list})
 
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+
 # ######################################################################################################################
 # * User Options  --------------------------------------------------------------
 option(USE_LIBNVFOREST_WHEEL "Use libnvforest wheel to provide some dependencies" OFF)


### PR DESCRIPTION
Adds `rapids_cython_find_prefix_paths()` so direct CMake builds in pip environments can discover packages provided by installed wheels.

Part of rapidsai/build-planning#325.