### PR TITLE
Update devcontainers to 26.12

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -5,22 +5,22 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "conda",
-      "BASE": "rapidsai/devcontainers:26.08-cpp-mambaforge"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/nvforest/devcontainer:26.08-cuda12.9-conda"
+      "ghcr.io/rapidsai/nvforest/devcontainer:26.12-cuda12.9-conda"
     ]
   },
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.08-cuda12.9-conda",
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.12-cuda12.9-conda",
     "--ulimit",
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.8": {}
+    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.12": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils"

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -5,29 +5,29 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:26.08-cpp-cuda12.9-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda12.9-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/nvforest/devcontainer:26.08-cuda12.9-pip"
+      "ghcr.io/rapidsai/nvforest/devcontainer:26.12-cuda12.9-pip"
     ]
   },
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.08-cuda12.9-pip",
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.12-cuda12.9-pip",
     "--ulimit",
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/cuda:26.8": {
+    "ghcr.io/rapidsai/devcontainers/features/cuda:26.12": {
       "version": "12.9",
       "installcuBLAS": false,
       "installcuSOLVER": false,
       "installcuRAND": false,
       "installcuSPARSE": false
     },
-    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.8": {}
+    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.12": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/cuda",

--- a/.devcontainer/cuda13.3-conda/devcontainer.json
+++ b/.devcontainer/cuda13.3-conda/devcontainer.json
@@ -5,22 +5,22 @@
     "args": {
       "CUDA": "13.3",
       "PYTHON_PACKAGE_MANAGER": "conda",
-      "BASE": "rapidsai/devcontainers:26.08-cpp-mambaforge"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/nvforest/devcontainer:26.08-cuda13.3-conda"
+      "ghcr.io/rapidsai/nvforest/devcontainer:26.12-cuda13.3-conda"
     ]
   },
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.08-cuda13.3-conda",
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.12-cuda13.3-conda",
     "--ulimit",
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.8": {}
+    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.12": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils"

--- a/.devcontainer/cuda13.3-pip/devcontainer.json
+++ b/.devcontainer/cuda13.3-pip/devcontainer.json
@@ -5,29 +5,29 @@
     "args": {
       "CUDA": "13.3",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:26.08-cpp-cuda13.3-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda13.3-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/nvforest/devcontainer:26.08-cuda13.3-pip"
+      "ghcr.io/rapidsai/nvforest/devcontainer:26.12-cuda13.3-pip"
     ]
   },
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.08-cuda13.3-pip",
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.12-cuda13.3-pip",
     "--ulimit",
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/cuda:26.8": {
+    "ghcr.io/rapidsai/devcontainers/features/cuda:26.12": {
       "version": "13.3",
       "installcuBLAS": false,
       "installcuSOLVER": false,
       "installcuRAND": false,
       "installcuSPARSE": false
     },
-    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.8": {}
+    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.12": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/cuda",


### PR DESCRIPTION
nvforest retained 26.08 base images, cache keys, container names, and 26.8 feature references after later release updates. Align all four CUDA/package-manager configurations with the current 26.12 devcontainer release so local development and cached images use the active train. Update the pip base tags to UCX 1.21.0 because that is the published dependency combination for the 26.12 images.

This supersedes #217 