### PR TITLE
Remove `rapidsai` from channel resolution to avoid `rapids-xgboost`

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - breathe

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - breathe

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - breathe

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - breathe

--- a/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/clang_tidy_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-133_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/conda/environments/cpp_all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-133_arch-x86_64.yaml
@@ -2,7 +2,6 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - rapidsai-nightly
-- rapidsai
 - conda-forge
 dependencies:
 - c-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -169,7 +169,6 @@ files:
       - depends_on_rapids_logger
 channels:
   - rapidsai-nightly
-  - rapidsai
   - conda-forge
 dependencies:
   rapids_build_backend:


### PR DESCRIPTION
Unblock the CI by temporarily removing `rapidsai` from channel resolution. Right now, the CI is pulling an old version of XGBoost due to the recent removal of `rapids-xgboost`. See https://github.com/NVIDIA/cuml/pull/8596 for the context.

Closes #222
